### PR TITLE
Caching Feature For DownloadManager

### DIFF
--- a/App/App.csproj
+++ b/App/App.csproj
@@ -29,6 +29,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ILMerge" Version="2.13.0307" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="mscorlib" />


### PR DESCRIPTION
First of all i found you soft very useful but it lucks some usability what i planning fix as many as i can.

To start want to contribute caching feature for download manager save directory and cookies.
Proofs why prompt save directory and cookie every time useless?
Every time prompting directory maybe not really usless. But what if you want save songs only in one directory for most users i think it very common case, if you want save directory select option.
Just need add normal options menu not only with reset option. By the way storing options in registry not good for portable application. But it's only my opinion.
In case with Cookies. Very simple if you session not expired authorization cookie woud be the same, so you dont need provide it every time, you only need provide it if you log out from you account and log in again.
So i think this feature will be usable at least for me.

Summary:
Added Newtonsoft.Json dependency
Changed AskUserForSaveDirectoryAndLogin in OsuDownloadManager.cs function with adding caching feature.

Since for now username and password field in Login Data structure dont provided by default dialog and don't make sense i decide to just hardcode it for purpose of minimal impact on the code outside the class.