### PR TITLE
Add: Cache download directory & osu! login cookies

### DIFF
--- a/App/App.csproj
+++ b/App/App.csproj
@@ -29,6 +29,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ILMerge" Version="2.13.0307" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="mscorlib" />

--- a/App/App.csproj
+++ b/App/App.csproj
@@ -29,7 +29,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ILMerge" Version="2.13.0307" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="mscorlib" />

--- a/App/OsuDownloadManager.cs
+++ b/App/OsuDownloadManager.cs
@@ -56,7 +56,6 @@ namespace App
             }
             if (!IsLoggedIn)
             {
-                //Do not forget change it once you change LoginData class
                 LogIn(new LoginData() { Password = "", Username = "", OsuCookies = Settings.Default.DownloadManager_AuthorizationCookies });
                 if (!IsLoggedIn)
                 {

--- a/App/OsuDownloadManager.cs
+++ b/App/OsuDownloadManager.cs
@@ -58,16 +58,13 @@ namespace App
             }
             if (!IsLoggedIn)
             {
-                if (!String.IsNullOrEmpty(Settings.Default.DownloadManager_AuthorizationCookies))
-                {
-                    //Do not forget change it once you change LoginData class
-                    LogIn(new LoginData() { Password = "", Username = "", OsuCookies = Settings.Default.DownloadManager_AuthorizationCookies });
-                }
-                else
+                //Do not forget change it once you change LoginData class
+                LogIn(new LoginData() { Password = "", Username = "", OsuCookies = Settings.Default.DownloadManager_AuthorizationCookies });
+                if (!IsLoggedIn)
                 {
                     LoginData ld = loginForm.GetLoginData();
                     LogIn(ld);
-                    Settings.Default.DownloadManager_AuthorizationCookies = ld.OsuCookies;
+                    Settings.Default.DownloadManager_AuthorizationCookies = ld?.OsuCookies;
                 }
             }
             return IsLoggedIn;

--- a/App/OsuDownloadManager.cs
+++ b/App/OsuDownloadManager.cs
@@ -30,8 +30,8 @@ namespace App
         public event EventHandler<EventArgs<DownloadItem>> DownloadItemUpdated;
 
         public bool IsLoggedIn { get; private set; } = false;
-        public string DownloadDirectory { get; set; } = "";
-        public bool DownloadDirectoryIsSet => DownloadDirectory != "";
+        public string DownloadDirectory { get; set; } = string.Empty;
+        public bool DownloadDirectoryIsSet => !string.IsNullOrEmpty(DownloadDirectory);
         private long _downloadId = 0;
         private const string BaseDownloadUrl = "https://osu.ppy.sh/beatmapsets/{0}/download";
         public bool? DownloadWithVideo { get; set; }
@@ -39,14 +39,10 @@ namespace App
         {
             if (!DownloadDirectoryIsSet)
             {
-                if(!String.IsNullOrEmpty(Settings.Default.DownloadManager_SaveDirectory))
-                {
-                    SetDownloadDirectory(Settings.Default.DownloadManager_SaveDirectory);
-                }
-                else
-                {
-                    SetDownloadDirectory(userDialogs.SelectDirectory("Select directory for saved beatmaps", true));
-                }
+                var downloadDirectory = string.IsNullOrEmpty(Settings.Default.DownloadManager_SaveDirectory)
+                    ? userDialogs.SelectDirectory("Select directory for saved beatmaps", true)
+                    : Settings.Default.DownloadManager_SaveDirectory;
+                SetDownloadDirectory(downloadDirectory);
 
                 if (!DownloadDirectoryIsSet)
                     return false;
@@ -79,7 +75,7 @@ namespace App
 
         public void PauseDownloads()
         {
-            if(_osuDownloader!=null)
+            if (_osuDownloader != null)
                 _osuDownloader.StopDownloads = true;
         }
         public void ResumeDownloads()

--- a/App/OsuDownloadManager.cs
+++ b/App/OsuDownloadManager.cs
@@ -1,5 +1,4 @@
 using System;
-using System.IO;
 using System.Collections.Generic;
 using System.Net;
 using App.Misc;
@@ -9,7 +8,6 @@ using CollectionManagerExtensionsDll.Modules.DownloadManager.API;
 using Common;
 using Gui.Misc;
 using GuiComponents.Interfaces;
-using Newtonsoft.Json;
 
 namespace App
 {
@@ -35,47 +33,26 @@ namespace App
         private long _downloadId = 0;
         private const string BaseDownloadUrl = "https://osu.ppy.sh/beatmapsets/{0}/download";
         public bool? DownloadWithVideo { get; set; }
-
-        private String CacheFile = "cache.json";
         public bool AskUserForSaveDirectoryAndLogin(IUserDialogs userDialogs, ILoginFormView loginForm)
         {
-            Dictionary<String, String> dict = null;
-            if (File.Exists(this.CacheFile))
-            {
-                using (StreamReader file = File.OpenText(this.CacheFile))
-                    dict = (Dictionary<string,string>)JsonConvert.DeserializeObject<Dictionary<string, string>>(file.ReadToEnd());
-                SetDownloadDirectory(dict["DownloadDirectory"]);
-                DownloadWithVideo = Convert.ToBoolean(dict["DownloadWithVideo"]);
-                LogIn(new LoginData() { Password = "5252353252", Username = "634636346242", OsuCookies = dict["Cookies"] });
-                if(IsLoggedIn)
-                    return true;
-            }
-            dict = new Dictionary<string, string>();
             if (!DownloadDirectoryIsSet)
             {
                 SetDownloadDirectory(userDialogs.SelectDirectory("Select directory for saved beatmaps", true));
                 if (!DownloadDirectoryIsSet)
                     return false;
-                dict.Add("DownloadDirectory", this.DownloadDirectory);
             }
 
             if (!DownloadWithVideo.HasValue)
             {
                 DownloadWithVideo = userDialogs.YesNoMessageBox("Download beatmaps with video?", "Beatmap downloader",
                     MessageBoxType.Question);
-                dict.Add("DownloadWithVideo", DownloadWithVideo.ToString());
             }
             if (!IsLoggedIn)
             {
-		LoginData data = loginForm.GetLoginData();
-                LogIn(data);
+                LogIn(loginForm.GetLoginData());
                 if (!IsLoggedIn)
                     return false;
-                dict.Add("Cookies", data.OsuCookies);
             }
-            using(StreamWriter file = File.CreateText(this.CacheFile))
-                file.Write(JsonConvert.SerializeObject(dict));
-
             return true;
         }
         public void DownloadBeatmap(Beatmap beatmap)

--- a/App/OsuDownloadManager.cs
+++ b/App/OsuDownloadManager.cs
@@ -47,8 +47,10 @@ namespace App
                 {
                     SetDownloadDirectory(userDialogs.SelectDirectory("Select directory for saved beatmaps", true));
                 }
+
                 if (!DownloadDirectoryIsSet)
                     return false;
+
                 Settings.Default.DownloadManager_SaveDirectory = DownloadDirectory;
             }
             if (!DownloadWithVideo.HasValue)

--- a/App/Properties/Settings.Designer.cs
+++ b/App/Properties/Settings.Designer.cs
@@ -94,5 +94,35 @@ namespace App.Properties {
                 this["OsuDirectory"] = value;
             }
         }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string DownloadManager_SaveDirectory
+        {
+            get
+            {
+                return ((string)(this["DownloadManager_SaveDirectory"]));
+            }
+            set
+            {
+                this["DownloadManager_SaveDirectory"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string DownloadManager_AuthorizationCookies
+        {
+            get
+            {
+                return ((string)(this["DownloadManager_AuthorizationCookies"]));
+            }
+            set
+            {
+                this["DownloadManager_AuthorizationCookies"] = value;
+            }
+        }
     }
 }

--- a/App/Properties/Settings.Designer.cs
+++ b/App/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace App.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.4.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.8.1.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -94,33 +94,27 @@ namespace App.Properties {
                 this["OsuDirectory"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("")]
-        public string DownloadManager_SaveDirectory
-        {
-            get
-            {
+        public string DownloadManager_SaveDirectory {
+            get {
                 return ((string)(this["DownloadManager_SaveDirectory"]));
             }
-            set
-            {
+            set {
                 this["DownloadManager_SaveDirectory"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("")]
-        public string DownloadManager_AuthorizationCookies
-        {
-            get
-            {
+        public string DownloadManager_AuthorizationCookies {
+            get {
                 return ((string)(this["DownloadManager_AuthorizationCookies"]));
             }
-            set
-            {
+            set {
                 this["DownloadManager_AuthorizationCookies"] = value;
             }
         }

--- a/App/Properties/Settings.settings
+++ b/App/Properties/Settings.settings
@@ -20,5 +20,11 @@
     <Setting Name="OsuDirectory" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
+    <Setting Name="DownloadManager_SaveDirectory" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
+    <Setting Name="DownloadManager_AuthorizationCookies" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/App/SidePanelActionsHandler.cs
+++ b/App/SidePanelActionsHandler.cs
@@ -96,7 +96,7 @@ namespace App
 
         private void ChangeDownloadDirectory(object arg1, object arg2)
         {
-            Settings.Default.DownloadManager_SaveDirectory = _userDialogs.SelectDirectory("Select new download directory. Changes take effect only after reboot application.");
+            Settings.Default.DownloadManager_SaveDirectory = _userDialogs.SelectDirectory("Select new download directory. Restart Collection Manager for the changes to take effect.");
         }
 
         private void ResetApplicationSettings(object arg1, object arg2)

--- a/App/SidePanelActionsHandler.cs
+++ b/App/SidePanelActionsHandler.cs
@@ -83,7 +83,8 @@ namespace App
                 {MainSidePanelActions.UploadCollectionChanges, UploadCollectionChanges },
                 {MainSidePanelActions.UploadNewCollections, UploadNewCollections },
                 {MainSidePanelActions.RemoveWebCollection ,RemoveWebCollection },
-                {MainSidePanelActions.ResetApplicationSettings,ResetApplicationSettings }
+                {MainSidePanelActions.ResetApplicationSettings,ResetApplicationSettings },
+                {MainSidePanelActions.ChangeDownloadDirectory,ChangeDownloadDirectory }
             };
 
             _mainForm.SidePanelView.SidePanelOperation += SidePanelViewOnSidePanelOperation;
@@ -91,6 +92,11 @@ namespace App
             _mainForm.CombinedListingView.CollectionListingView.OnLoadFile += OnLoadFile;
             _mainFormPresenter.InfoTextModel.UpdateTextClicked += FormUpdateTextClicked;
             _mainForm.Closing += FormOnClosing;
+        }
+
+        private void ChangeDownloadDirectory(object arg1, object arg2)
+        {
+            Settings.Default.DownloadManager_SaveDirectory = _userDialogs.SelectDirectory("Select new download directory. Changes take effect only after reboot application.");
         }
 
         private void ResetApplicationSettings(object arg1, object arg2)

--- a/App/app.config
+++ b/App/app.config
@@ -26,6 +26,12 @@
             <setting name="OsuDirectory" serializeAs="String">
                 <value />
             </setting>
+            <setting name="DownloadManager_SaveDirectory" serializeAs="String">
+                <value />
+            </setting>
+            <setting name="DownloadManager_AuthorizationCookies" serializeAs="String">
+                <value />
+            </setting>
         </App.Properties.Settings>
     </userSettings>
 </configuration>

--- a/Common/MainSidePanelActions.cs
+++ b/Common/MainSidePanelActions.cs
@@ -20,6 +20,7 @@
         UploadNewCollections,
         RemoveWebCollection,
         SaveDefaultCollection,
-        ResetApplicationSettings
+        ResetApplicationSettings,
+        ChangeDownloadDirectory
     }
 }

--- a/GuiComponents/Controls/MainSidePanelView.Designer.cs
+++ b/GuiComponents/Controls/MainSidePanelView.Designer.cs
@@ -44,6 +44,7 @@
             this.onlineToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.Menu_mapDownloads = new System.Windows.Forms.ToolStripMenuItem();
             this.Menu_downloadAllMissing = new System.Windows.Forms.ToolStripMenuItem();
+            this.Menu_changeSaveDirectory = new System.Windows.Forms.ToolStripMenuItem();
             this.Menu_GenerateCollections = new System.Windows.Forms.ToolStripMenuItem();
             this.Menu_GetMissingMapData = new System.Windows.Forms.ToolStripMenuItem();
             this.osustatsCollectionsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -166,6 +167,7 @@
             this.onlineToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.Menu_mapDownloads,
             this.Menu_downloadAllMissing,
+            this.Menu_changeSaveDirectory,
             this.Menu_GenerateCollections,
             this.Menu_GetMissingMapData});
             this.onlineToolStripMenuItem.Name = "onlineToolStripMenuItem";
@@ -183,6 +185,13 @@
             this.Menu_downloadAllMissing.Name = "Menu_downloadAllMissing";
             this.Menu_downloadAllMissing.Size = new System.Drawing.Size(219, 22);
             this.Menu_downloadAllMissing.Text = "Download all missing maps";
+            // 
+            // Menu_changeSaveDirectory
+            // 
+            this.Menu_changeSaveDirectory.AccessibleName = "";
+            this.Menu_changeSaveDirectory.Name = "Menu_changeSaveDirectory";
+            this.Menu_changeSaveDirectory.Size = new System.Drawing.Size(219, 22);
+            this.Menu_changeSaveDirectory.Text = "Change save directory";
             // 
             // Menu_GenerateCollections
             // 
@@ -310,5 +319,6 @@
         private System.Windows.Forms.ToolStripMenuItem Menu_saveOsuCollection;
         private System.Windows.Forms.ToolStripMenuItem settingsToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem Menu_resetSettings;
+        private System.Windows.Forms.ToolStripMenuItem Menu_changeSaveDirectory;
     }
 }

--- a/GuiComponents/Controls/MainSidePanelView.cs
+++ b/GuiComponents/Controls/MainSidePanelView.cs
@@ -51,6 +51,7 @@ namespace GuiComponents.Controls
             Menu_osustatsLogin.Click += (s, a) => SidePanelOperation?.Invoke(this, MainSidePanelActions.OsustatsLogin);
             Menu_saveOsuCollection.Click += (s, a) => SidePanelOperation?.Invoke(this, MainSidePanelActions.SaveDefaultCollection);
             Menu_resetSettings.Click += (s, a) => SidePanelOperation?.Invoke(this,MainSidePanelActions.ResetApplicationSettings);
+            Menu_changeSaveDirectory.Click += (s, a) => SidePanelOperation?.Invoke(this, MainSidePanelActions.ChangeDownloadDirectory);
 
             WebCollections.CollectionChanged += WebCollectionsOnCollectionChanged;
         }


### PR DESCRIPTION
1. Added caching using Settings designer object.
2. Added change save directory item in online menu which changes directory in Settings object so need to restart application to take effect on OsuDownloadManager itself.
3. Removed DownloadWithVideo download setting caching cause of clicking this form it's not big deal.
4. With LoginData class unfortunately i can't do anything. I'll just leave it at you.