### PR TITLE
Add: Difference of collections

### DIFF
--- a/App/CollectionEditor.cs
+++ b/App/CollectionEditor.cs
@@ -48,7 +48,7 @@ namespace App
                         break;
                 }
             }
-            else if (e.Action == CollectionEdit.Intersect)
+            else if (e.Action == CollectionEdit.Intersect || e.Action == CollectionEdit.Difference)
             {
                 if (e.Collections.Count < 2)
                     return;

--- a/App/Presenters/Controls/CollectionListingPresenter.cs
+++ b/App/Presenters/Controls/CollectionListingPresenter.cs
@@ -85,6 +85,11 @@ namespace App.Presenters.Controls
                         return;
                     args = CollectionEditArgs.InverseCollections(selectedCollections, selectedCollections[0].Name);
                     break;
+                case "Difference":
+                    if (selectedCollections == null)
+                        return;
+                    args = CollectionEditArgs.DifferenceCollections(selectedCollections, selectedCollections[0].Name);
+                    break;
                 case "Create":
                     args = CollectionEditArgs.AddCollections(null);
                     break;

--- a/CollectionManagerDll/Enums/CollectionEdit.cs
+++ b/CollectionManagerDll/Enums/CollectionEdit.cs
@@ -13,5 +13,6 @@
         Duplicate=8,
         Intersect=9,
         Inverse=10,
+        Difference=11,
     }
 }

--- a/CollectionManagerDll/Modules/CollectionsManager/CollectionEditArgs.cs
+++ b/CollectionManagerDll/Modules/CollectionsManager/CollectionEditArgs.cs
@@ -88,6 +88,16 @@ namespace CollectionManager.Modules.CollectionsManager
             };
         }
         #endregion
+        #region Difference Collections
+        public static CollectionEditArgs DifferenceCollections(Collections collections, string newName)
+        {
+            return new CollectionEditArgs(CollectionEdit.Difference)
+            {
+                Collections = collections,
+                NewName = newName
+            };
+        }
+        #endregion
         #region Clear Collections
         public static CollectionEditArgs ClearCollections()
         {

--- a/CollectionManagerDll/Modules/CollectionsManager/CollectionsManager.cs
+++ b/CollectionManagerDll/Modules/CollectionsManager/CollectionsManager.cs
@@ -134,12 +134,12 @@ namespace CollectionManager.Modules.CollectionsManager
                     beatmaps = beatmaps.Concat(collection.AllBeatmaps());
                 }
 
-                var difference_Md5 = beatmaps.GroupBy(x => x.Md5).Where(group => group.Count() == 1).Select(group => group.Key).ToList();
-                var difference_MapId = beatmaps.GroupBy(x => x.MapId).Where(group => group.Count() == 1).Select(group => group.Key).ToList();
+                var differenceMd5 = beatmaps.GroupBy(x => x.Md5).Where(group => group.Count() == 1).Select(group => group.Key).ToList();
+                var differenceMapId = beatmaps.GroupBy(x => x.MapId).Where(group => group.Count() == 1).Select(group => group.Key).ToList();
 
                 foreach (var beatmap in beatmaps)
                 {
-                    if (difference_Md5.Contains(beatmap.Md5) || difference_MapId.Contains(beatmap.MapId))
+                    if (differenceMd5.Contains(beatmap.Md5) || differenceMapId.Contains(beatmap.MapId))
                     {
                         targetCollection.AddBeatmap(beatmap);
                     }

--- a/CollectionManagerDll/Modules/CollectionsManager/CollectionsManager.cs
+++ b/CollectionManagerDll/Modules/CollectionsManager/CollectionsManager.cs
@@ -23,6 +23,7 @@ namespace CollectionManager.Modules.CollectionsManager
          merge x collections
          intersect x collections
          inverse map sum of x collections
+         difference x collections
          clear collections
          add beatmaps to collection
          remove beatmaps from collection
@@ -112,6 +113,25 @@ namespace CollectionManager.Modules.CollectionsManager
                 foreach (var collection in args.Collections)
                 {
                     beatmaps = beatmaps.Except(collection.AllBeatmaps(), new CollectionBeatmapComparer());
+                }
+
+                foreach (var beatmap in beatmaps)
+                {
+                    targetCollection.AddBeatmap(beatmap);
+                }
+
+                EditCollection(CollectionEditArgs.AddCollections(new Collections() { targetCollection }), true);
+            }
+            else if (action == CollectionEdit.Difference)
+            {
+                var targetCollection = args.Collections.Last();
+                args.Collections.RemoveAt(args.Collections.Count - 1);
+                var mainCollection = args.Collections[0];
+                args.Collections.RemoveAt(0);
+                var beatmaps = mainCollection.AllBeatmaps();
+                foreach (var collection in args.Collections)
+                {
+                    beatmaps = beatmaps.Except(collection.AllBeatmaps(), new CollectionBeatmapComparer()).Union(collection.AllBeatmaps().Except(beatmaps, new CollectionBeatmapComparer()));
                 }
 
                 foreach (var beatmap in beatmaps)

--- a/CollectionManagerDll/Modules/CollectionsManager/CollectionsManager.cs
+++ b/CollectionManagerDll/Modules/CollectionsManager/CollectionsManager.cs
@@ -131,12 +131,17 @@ namespace CollectionManager.Modules.CollectionsManager
                 var beatmaps = mainCollection.AllBeatmaps();
                 foreach (var collection in args.Collections)
                 {
-                    beatmaps = beatmaps.Except(collection.AllBeatmaps(), new CollectionBeatmapComparer()).Union(collection.AllBeatmaps().Except(beatmaps, new CollectionBeatmapComparer()));
+                    beatmaps = beatmaps.Concat(collection.AllBeatmaps());
                 }
+
+                var difference_md5 = beatmaps.GroupBy(x => x.Md5).Where(group => group.Count() == 1).Select(group => group.Key).ToList();
 
                 foreach (var beatmap in beatmaps)
                 {
-                    targetCollection.AddBeatmap(beatmap);
+                    if (difference_md5.Contains(beatmap.Md5))
+                    {
+                        targetCollection.AddBeatmap(beatmap);
+                    }
                 }
 
                 EditCollection(CollectionEditArgs.AddCollections(new Collections() { targetCollection }), true);

--- a/CollectionManagerDll/Modules/CollectionsManager/CollectionsManager.cs
+++ b/CollectionManagerDll/Modules/CollectionsManager/CollectionsManager.cs
@@ -134,11 +134,12 @@ namespace CollectionManager.Modules.CollectionsManager
                     beatmaps = beatmaps.Concat(collection.AllBeatmaps());
                 }
 
-                var difference_md5 = beatmaps.GroupBy(x => x.Md5).Where(group => group.Count() == 1).Select(group => group.Key).ToList();
+                var difference_Md5 = beatmaps.GroupBy(x => x.Md5).Where(group => group.Count() == 1).Select(group => group.Key).ToList();
+                var difference_MapId = beatmaps.GroupBy(x => x.MapId).Where(group => group.Count() == 1).Select(group => group.Key).ToList();
 
                 foreach (var beatmap in beatmaps)
                 {
-                    if (difference_md5.Contains(beatmap.Md5))
+                    if (difference_Md5.Contains(beatmap.Md5) || difference_MapId.Contains(beatmap.MapId))
                     {
                         targetCollection.AddBeatmap(beatmap);
                     }

--- a/GuiComponents/Controls/CollectionListingView.Designer.cs
+++ b/GuiComponents/Controls/CollectionListingView.Designer.cs
@@ -36,7 +36,6 @@
             this.Total = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
             this.olvColumn2 = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
             this.textBox_collectionNameSearch = new System.Windows.Forms.TextBox();
-            this.CollectionContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.CreateMenuStrip = new System.Windows.Forms.ToolStripMenuItem();
             this.renameCollectionMenuStrip = new System.Windows.Forms.ToolStripMenuItem();
             this.deleteCollectionMenuStrip = new System.Windows.Forms.ToolStripMenuItem();
@@ -45,7 +44,9 @@
             this.DuplicateMenuStrip = new System.Windows.Forms.ToolStripMenuItem();
             this.mergeWithMenuStrip = new System.Windows.Forms.ToolStripMenuItem();
             this.intersectMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.differenceMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.inverseToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.CollectionContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.panel1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.ListViewCollections)).BeginInit();
             this.CollectionContextMenuStrip.SuspendLayout();
@@ -126,6 +127,100 @@
             this.textBox_collectionNameSearch.Size = new System.Drawing.Size(463, 20);
             this.textBox_collectionNameSearch.TabIndex = 1;
             // 
+            // CreateMenuStrip
+            // 
+            this.CreateMenuStrip.Name = "CreateMenuStrip";
+            this.CreateMenuStrip.Size = new System.Drawing.Size(180, 22);
+            this.CreateMenuStrip.Tag = "Create";
+            this.CreateMenuStrip.Text = "Create";
+            this.CreateMenuStrip.ToolTipText = "Create new collection";
+            this.CreateMenuStrip.Click += new System.EventHandler(this.MenuStripClick);
+            // 
+            // renameCollectionMenuStrip
+            // 
+            this.renameCollectionMenuStrip.Name = "renameCollectionMenuStrip";
+            this.renameCollectionMenuStrip.ShortcutKeyDisplayString = "F2";
+            this.renameCollectionMenuStrip.Size = new System.Drawing.Size(180, 22);
+            this.renameCollectionMenuStrip.Tag = "Rename";
+            this.renameCollectionMenuStrip.Text = "Rename";
+            this.renameCollectionMenuStrip.ToolTipText = "Rename currently selected collection";
+            this.renameCollectionMenuStrip.Click += new System.EventHandler(this.MenuStripClick);
+            // 
+            // deleteCollectionMenuStrip
+            // 
+            this.deleteCollectionMenuStrip.Name = "deleteCollectionMenuStrip";
+            this.deleteCollectionMenuStrip.ShortcutKeyDisplayString = "Del";
+            this.deleteCollectionMenuStrip.Size = new System.Drawing.Size(180, 22);
+            this.deleteCollectionMenuStrip.Tag = "Delete";
+            this.deleteCollectionMenuStrip.Text = "Delete";
+            this.deleteCollectionMenuStrip.ToolTipText = "Delete currently selected collections";
+            this.deleteCollectionMenuStrip.Click += new System.EventHandler(this.MenuStripClick);
+            // 
+            // copyToolStripMenuItem
+            // 
+            this.copyToolStripMenuItem.Name = "copyToolStripMenuItem";
+            this.copyToolStripMenuItem.ShortcutKeyDisplayString = "Ctrl+C";
+            this.copyToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.copyToolStripMenuItem.Tag = "Copy";
+            this.copyToolStripMenuItem.Text = "Copy";
+            this.copyToolStripMenuItem.Click += new System.EventHandler(this.MenuStripClick);
+            // 
+            // pasteToolStripMenuItem
+            // 
+            this.pasteToolStripMenuItem.Name = "pasteToolStripMenuItem";
+            this.pasteToolStripMenuItem.ShortcutKeyDisplayString = "Ctrl+V";
+            this.pasteToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.pasteToolStripMenuItem.Tag = "Paste";
+            this.pasteToolStripMenuItem.Text = "Paste";
+            this.pasteToolStripMenuItem.Click += new System.EventHandler(this.MenuStripClick);
+            // 
+            // DuplicateMenuStrip
+            // 
+            this.DuplicateMenuStrip.Name = "DuplicateMenuStrip";
+            this.DuplicateMenuStrip.Size = new System.Drawing.Size(180, 22);
+            this.DuplicateMenuStrip.Tag = "Duplicate";
+            this.DuplicateMenuStrip.Text = "Duplicate";
+            this.DuplicateMenuStrip.ToolTipText = "Create a copy of currently selected collection";
+            this.DuplicateMenuStrip.Click += new System.EventHandler(this.MenuStripClick);
+            // 
+            // mergeWithMenuStrip
+            // 
+            this.mergeWithMenuStrip.Name = "mergeWithMenuStrip";
+            this.mergeWithMenuStrip.Size = new System.Drawing.Size(180, 22);
+            this.mergeWithMenuStrip.Tag = "Merge";
+            this.mergeWithMenuStrip.Text = "Merge selected";
+            this.mergeWithMenuStrip.ToolTipText = "Merge beatmaps from selected collections into new collection";
+            this.mergeWithMenuStrip.Click += new System.EventHandler(this.MenuStripClick);
+            // 
+            // intersectMenuItem
+            // 
+            this.intersectMenuItem.Name = "intersectMenuItem";
+            this.intersectMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.intersectMenuItem.Tag = "Intersect";
+            this.intersectMenuItem.Text = "Intersection";
+            this.intersectMenuItem.ToolTipText = "Create a collection that contains beatmaps that exist in all selected collections" +
+    "";
+            this.intersectMenuItem.Click += new System.EventHandler(this.MenuStripClick);
+            // 
+            // differenceToolStripMenuItem
+            // 
+            this.differenceMenuItem.Name = "differenceToolStripMenuItem";
+            this.differenceMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.differenceMenuItem.Tag = "Difference";
+            this.differenceMenuItem.Text = "Difference";
+            this.differenceMenuItem.ToolTipText = "Create a collection that contains beatmaps that exist in only one of the selected collections";
+            this.differenceMenuItem.Click += new System.EventHandler(this.MenuStripClick);
+            // 
+            // inverseToolStripMenuItem
+            // 
+            this.inverseToolStripMenuItem.Name = "inverseToolStripMenuItem";
+            this.inverseToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.inverseToolStripMenuItem.Tag = "Inverse";
+            this.inverseToolStripMenuItem.Text = "Inverse";
+            this.inverseToolStripMenuItem.ToolTipText = "Create new collection that contains every beatmap not present in all selected col" +
+    "lections";
+            this.inverseToolStripMenuItem.Click += new System.EventHandler(this.MenuStripClick);
+            // 
             // CollectionContextMenuStrip
             // 
             this.CollectionContextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
@@ -137,94 +232,10 @@
             this.DuplicateMenuStrip,
             this.mergeWithMenuStrip,
             this.intersectMenuItem,
+            this.differenceMenuItem,
             this.inverseToolStripMenuItem});
             this.CollectionContextMenuStrip.Name = "CollectionContextMenuStrip";
-            this.CollectionContextMenuStrip.Size = new System.Drawing.Size(155, 202);
-            // 
-            // CreateMenuStrip
-            // 
-            this.CreateMenuStrip.Name = "CreateMenuStrip";
-            this.CreateMenuStrip.Size = new System.Drawing.Size(154, 22);
-            this.CreateMenuStrip.Tag = "Create";
-            this.CreateMenuStrip.Text = "Create";
-            this.CreateMenuStrip.ToolTipText = "Create new collection";
-            this.CreateMenuStrip.Click += new System.EventHandler(this.MenuStripClick);
-            // 
-            // renameCollectionMenuStrip
-            // 
-            this.renameCollectionMenuStrip.Name = "renameCollectionMenuStrip";
-            this.renameCollectionMenuStrip.ShortcutKeyDisplayString = "F2";
-            this.renameCollectionMenuStrip.Size = new System.Drawing.Size(154, 22);
-            this.renameCollectionMenuStrip.Tag = "Rename";
-            this.renameCollectionMenuStrip.Text = "Rename";
-            this.renameCollectionMenuStrip.ToolTipText = "Rename currently selected collection";
-            this.renameCollectionMenuStrip.Click += new System.EventHandler(this.MenuStripClick);
-            // 
-            // deleteCollectionMenuStrip
-            // 
-            this.deleteCollectionMenuStrip.Name = "deleteCollectionMenuStrip";
-            this.deleteCollectionMenuStrip.ShortcutKeyDisplayString = "Del";
-            this.deleteCollectionMenuStrip.Size = new System.Drawing.Size(154, 22);
-            this.deleteCollectionMenuStrip.Tag = "Delete";
-            this.deleteCollectionMenuStrip.Text = "Delete";
-            this.deleteCollectionMenuStrip.ToolTipText = "Delete currently selected collections";
-            this.deleteCollectionMenuStrip.Click += new System.EventHandler(this.MenuStripClick);
-            // 
-            // copyToolStripMenuItem
-            // 
-            this.copyToolStripMenuItem.Name = "copyToolStripMenuItem";
-            this.copyToolStripMenuItem.ShortcutKeyDisplayString = "Ctrl+C";
-            this.copyToolStripMenuItem.Size = new System.Drawing.Size(154, 22);
-            this.copyToolStripMenuItem.Tag = "Copy";
-            this.copyToolStripMenuItem.Text = "Copy";
-            this.copyToolStripMenuItem.Click += new System.EventHandler(this.MenuStripClick);
-            // 
-            // pasteToolStripMenuItem
-            // 
-            this.pasteToolStripMenuItem.Name = "pasteToolStripMenuItem";
-            this.pasteToolStripMenuItem.ShortcutKeyDisplayString = "Ctrl+V";
-            this.pasteToolStripMenuItem.Size = new System.Drawing.Size(154, 22);
-            this.pasteToolStripMenuItem.Tag = "Paste";
-            this.pasteToolStripMenuItem.Text = "Paste";
-            this.pasteToolStripMenuItem.Click += new System.EventHandler(this.MenuStripClick);
-            // 
-            // DuplicateMenuStrip
-            // 
-            this.DuplicateMenuStrip.Name = "DuplicateMenuStrip";
-            this.DuplicateMenuStrip.Size = new System.Drawing.Size(154, 22);
-            this.DuplicateMenuStrip.Tag = "Duplicate";
-            this.DuplicateMenuStrip.Text = "Duplicate";
-            this.DuplicateMenuStrip.ToolTipText = "Create a copy of currently selected collection";
-            this.DuplicateMenuStrip.Click += new System.EventHandler(this.MenuStripClick);
-            // 
-            // mergeWithMenuStrip
-            // 
-            this.mergeWithMenuStrip.Name = "mergeWithMenuStrip";
-            this.mergeWithMenuStrip.Size = new System.Drawing.Size(154, 22);
-            this.mergeWithMenuStrip.Tag = "Merge";
-            this.mergeWithMenuStrip.Text = "Merge selected";
-            this.mergeWithMenuStrip.ToolTipText = "Merge beatmaps from selected collections into new collection";
-            this.mergeWithMenuStrip.Click += new System.EventHandler(this.MenuStripClick);
-            // 
-            // intersectMenuItem
-            // 
-            this.intersectMenuItem.Name = "intersectMenuItem";
-            this.intersectMenuItem.Size = new System.Drawing.Size(154, 22);
-            this.intersectMenuItem.Tag = "Intersect";
-            this.intersectMenuItem.Text = "Intersection";
-            this.intersectMenuItem.ToolTipText = "Create a collection that contains beatmaps that exist in all selected collections" +
-    "";
-            this.intersectMenuItem.Click += new System.EventHandler(this.MenuStripClick);
-            // 
-            // inverseToolStripMenuItem
-            // 
-            this.inverseToolStripMenuItem.Name = "inverseToolStripMenuItem";
-            this.inverseToolStripMenuItem.Size = new System.Drawing.Size(154, 22);
-            this.inverseToolStripMenuItem.Tag = "Inverse";
-            this.inverseToolStripMenuItem.Text = "Inverse";
-            this.inverseToolStripMenuItem.ToolTipText = "Create new collection that contains every beatmap in the user\'s library that isn\'" +
-    "t in selected collections";
-            this.inverseToolStripMenuItem.Click += new System.EventHandler(this.MenuStripClick);
+            this.CollectionContextMenuStrip.Size = new System.Drawing.Size(181, 246);
             // 
             // CollectionListingView
             // 
@@ -249,16 +260,17 @@
         private BrightIdeasSoftware.OLVColumn olvColumn1;
         private BrightIdeasSoftware.OLVColumn olvColumn2;
         private System.Windows.Forms.TextBox textBox_collectionNameSearch;
-        private System.Windows.Forms.ContextMenuStrip CollectionContextMenuStrip;
+        private BrightIdeasSoftware.OLVColumn Total;
+        private System.Windows.Forms.ToolStripMenuItem CreateMenuStrip;
         private System.Windows.Forms.ToolStripMenuItem renameCollectionMenuStrip;
         private System.Windows.Forms.ToolStripMenuItem deleteCollectionMenuStrip;
-        private System.Windows.Forms.ToolStripMenuItem mergeWithMenuStrip;
-        private System.Windows.Forms.ToolStripMenuItem CreateMenuStrip;
-        private BrightIdeasSoftware.OLVColumn Total;
-        private System.Windows.Forms.ToolStripMenuItem DuplicateMenuStrip;
-        private System.Windows.Forms.ToolStripMenuItem intersectMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem inverseToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem copyToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem pasteToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem DuplicateMenuStrip;
+        private System.Windows.Forms.ToolStripMenuItem mergeWithMenuStrip;
+        private System.Windows.Forms.ToolStripMenuItem intersectMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem differenceMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem inverseToolStripMenuItem;
+        private System.Windows.Forms.ContextMenuStrip CollectionContextMenuStrip;
     }
 }

--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ The following opinions are made available by right clicking in the left panel:
 
   The new collection is named using the selected collection closest to the top of the listing, with `_0` appended to its name.
 
+- Difference: Differentiates all selected collections by making a new collection with only maps that are present in only one selected collection.
+
+  The new collection is named using the selected collection closest to the top of the listing, with `_0` appended to its name.
+
 - Inverse: Inverses all selected collections by making a new collection with only maps that are not present in any of the selected collections but are present in your osu! songs folder.
 
   The new collection is named using the selected collection closest to the top of the listing, with `_0` appended to its name.


### PR DESCRIPTION
Fixes #57 

This isn't an exact opposite of intersect but I don't think that is necessary. It instead makes a collection with only maps present in one of the selected collections.

It is worth noting that the exact filter mentioned in #57 can be achieved with the following method (for only two collections this is irrelevant):
1. Intersect all collections that should be filtered
2. Merge all collections that should be filtered
3. Difference the resulting merged and intersected collections