### PR TITLE
Add: Reorder collections using different filters

### DIFF
--- a/App/Presenters/Controls/CollectionListingPresenter.cs
+++ b/App/Presenters/Controls/CollectionListingPresenter.cs
@@ -48,7 +48,7 @@ namespace App.Presenters.Controls
             Collections = _model.GetCollections();
         }
 
-        private void ViewOnCollectionReorder(object sender, Collections collections, Collection targetCollection, bool placeBefore)
+        private void ViewOnCollectionReorder(object sender, Collections collections, Collection targetCollection, bool placeBefore, string sortColumn, int sortOrder)
         {
             if (!Settings.Default.DontAskAboutReorderingCollections)
             {
@@ -60,7 +60,7 @@ namespace App.Presenters.Controls
                     return;
             }
 
-            _model.EmitCollectionEditing(CollectionEditArgs.ReorderCollections(collections, targetCollection, placeBefore));
+            _model.EmitCollectionEditing(CollectionEditArgs.ReorderCollections(collections, targetCollection, placeBefore, sortColumn, sortOrder));
         }
 
         private void ViewOnBeatmapsDropped(object sender, Beatmaps args, string collectionName)

--- a/App/Presenters/Controls/CollectionListingPresenter.cs
+++ b/App/Presenters/Controls/CollectionListingPresenter.cs
@@ -9,6 +9,8 @@ using System.Collections.Specialized;
 using App.Misc;
 using Common;
 using App.Properties;
+using CollectionManager.Enums;
+using SortOrder = CollectionManager.Enums.SortOrder;
 
 namespace App.Presenters.Controls
 {
@@ -48,7 +50,7 @@ namespace App.Presenters.Controls
             Collections = _model.GetCollections();
         }
 
-        private void ViewOnCollectionReorder(object sender, Collections collections, Collection targetCollection, bool placeBefore, string sortColumn, int sortOrder)
+        private void ViewOnCollectionReorder(object sender, Collections collections, Collection targetCollection, bool placeBefore, string sortColumn, SortOrder sortOrder)
         {
             if (!Settings.Default.DontAskAboutReorderingCollections)
             {

--- a/CollectionManagerDll/CollectionManagerDll.csproj
+++ b/CollectionManagerDll/CollectionManagerDll.csproj
@@ -18,6 +18,7 @@
     <Version>1.0.8</Version>
     <IncludeSymbols>true</IncludeSymbols> 
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+	<LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Remote Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>

--- a/CollectionManagerDll/Enums/SortOrder.cs
+++ b/CollectionManagerDll/Enums/SortOrder.cs
@@ -1,0 +1,8 @@
+﻿namespace CollectionManager.Enums
+{
+    public enum SortOrder
+    {
+        Descending,
+        Ascending,
+    }
+}

--- a/CollectionManagerDll/Modules/CollectionsManager/CollectionEditArgs.cs
+++ b/CollectionManagerDll/Modules/CollectionsManager/CollectionEditArgs.cs
@@ -15,6 +15,9 @@ namespace CollectionManager.Modules.CollectionsManager
         public Beatmaps Beatmaps { get; protected set; }
         public IList<string> CollectionNames { get; protected set; }
         public bool PlaceCollectionsBefore { get; protected set; }
+        public string SortColumn { get; private set; }
+        public int SortOrder { get; private set; }
+
         public CollectionEditArgs(CollectionEdit action)
         {
             Action = action;
@@ -118,13 +121,15 @@ namespace CollectionManager.Modules.CollectionsManager
 
         #endregion
         #region Reorder collections using special characters placed at the begining of the name, this modifies ALL collection names
-        public static CollectionEditArgs ReorderCollections(Collections collections, Collection targetCollection, bool placeBefore)
+        public static CollectionEditArgs ReorderCollections(Collections collections, Collection targetCollection, bool placeBefore, string sortColumn, int sortOrder)
         {
             return new CollectionEditArgs(CollectionEdit.Reorder)
             {
                 Collections = collections,
                 TargetCollection = targetCollection,
-                PlaceCollectionsBefore = placeBefore
+                PlaceCollectionsBefore = placeBefore,
+                SortColumn = sortColumn,
+                SortOrder = sortOrder
             };
         }
         #endregion

--- a/CollectionManagerDll/Modules/CollectionsManager/CollectionEditArgs.cs
+++ b/CollectionManagerDll/Modules/CollectionsManager/CollectionEditArgs.cs
@@ -16,7 +16,7 @@ namespace CollectionManager.Modules.CollectionsManager
         public IList<string> CollectionNames { get; protected set; }
         public bool PlaceCollectionsBefore { get; protected set; }
         public string SortColumn { get; private set; }
-        public int SortOrder { get; private set; }
+        public SortOrder SortOrder { get; private set; }
 
         public CollectionEditArgs(CollectionEdit action)
         {
@@ -121,7 +121,7 @@ namespace CollectionManager.Modules.CollectionsManager
 
         #endregion
         #region Reorder collections using special characters placed at the begining of the name, this modifies ALL collection names
-        public static CollectionEditArgs ReorderCollections(Collections collections, Collection targetCollection, bool placeBefore, string sortColumn, int sortOrder)
+        public static CollectionEditArgs ReorderCollections(Collections collections, Collection targetCollection, bool placeBefore, string sortColumn, SortOrder sortOrder)
         {
             return new CollectionEditArgs(CollectionEdit.Reorder)
             {

--- a/CollectionManagerDll/Modules/CollectionsManager/CollectionsManager.cs
+++ b/CollectionManagerDll/Modules/CollectionsManager/CollectionsManager.cs
@@ -163,9 +163,37 @@ namespace CollectionManager.Modules.CollectionsManager
             }
             else if (action == CollectionEdit.Reorder)
             {
-                var targetCollection = args.TargetCollection;
-                var collectionsToReorder = args.Collections.OrderBy(x => x.Name).ToList();
-                var orderedLoadedCollections = LoadedCollections.OrderBy(x => x.Name).ToList();
+                List<ICollection> collectionsToReorder;
+                List<ICollection> orderedLoadedCollections;
+                switch (args.SortColumn)
+                {
+                    case "Name":
+                        collectionsToReorder = args.Collections.OrderBy(x => x.Name).ToList();
+                        orderedLoadedCollections = LoadedCollections.OrderBy(x => x.Name).ToList();
+                        break;
+                    case "Count":
+                        collectionsToReorder = args.Collections.OrderBy(x => x.NumberOfBeatmaps).ToList();
+                        orderedLoadedCollections = LoadedCollections.OrderBy(x => x.NumberOfBeatmaps).ToList();
+                        break;
+                    case "Missing":
+                        collectionsToReorder = args.Collections.OrderBy(x => x.NumberOfMissingBeatmaps).ToList();
+                        orderedLoadedCollections = LoadedCollections.OrderBy(x => x.NumberOfMissingBeatmaps).ToList();
+                        break;
+                    case "Id":
+                        collectionsToReorder = args.Collections.OrderBy(x => x.Id).ToList();
+                        orderedLoadedCollections = LoadedCollections.OrderBy(x => x.Id).ToList();
+                        break;
+                    default:
+                        collectionsToReorder = args.Collections.OrderBy(x => x.Name).ToList();
+                        orderedLoadedCollections = LoadedCollections.OrderBy(x => x.Name).ToList();
+                        break;
+                }
+                if (args.SortOrder == 2)
+                {
+                    collectionsToReorder.Reverse();
+                    orderedLoadedCollections.Reverse();
+                }
+                    var targetCollection = args.TargetCollection;
                 foreach (var coll in collectionsToReorder)
                     orderedLoadedCollections.Remove(coll);
 

--- a/CollectionManagerDll/Modules/CollectionsManager/CollectionsManager.cs
+++ b/CollectionManagerDll/Modules/CollectionsManager/CollectionsManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -188,7 +188,7 @@ namespace CollectionManager.Modules.CollectionsManager
                         orderedLoadedCollections = LoadedCollections.OrderBy(x => x.Name).ToList();
                         break;
                 }
-                if (args.SortOrder == 2)
+                if (args.SortOrder == SortOrder.Ascending)
                 {
                     collectionsToReorder.Reverse();
                     orderedLoadedCollections.Reverse();

--- a/Common/GuiHelpers.cs
+++ b/Common/GuiHelpers.cs
@@ -1,4 +1,5 @@
-﻿using CollectionManager.DataTypes;
+﻿using BrightIdeasSoftware;
+using CollectionManager.DataTypes;
 using Common;
 
 namespace Gui.Misc
@@ -7,7 +8,7 @@ namespace Gui.Misc
     {
         public delegate void BeatmapsEventArgs(object sender, Beatmaps args);
         public delegate void CollectionBeatmapsEventArgs(object sender, Beatmaps args, string collectionName);
-        public delegate void CollectionReorderEventArgs(object sender, Collections collections, Collection targetCollection, bool placeBefore);
+        public delegate void CollectionReorderEventArgs(object sender, Collections collections, Collection targetCollection, bool placeBefore, string sortColumn, int sortOrder);
         public delegate void BeatmapListingActionArgs(object sender, BeatmapListingAction args);
         public delegate void SidePanelActionsHandlerArgs(object sender, MainSidePanelActions args, object data = null);
         public delegate void LoadFileArgs(object sender, string[] filePaths);

--- a/Common/GuiHelpers.cs
+++ b/Common/GuiHelpers.cs
@@ -1,5 +1,6 @@
 ﻿using BrightIdeasSoftware;
 using CollectionManager.DataTypes;
+using CollectionManager.Enums;
 using Common;
 
 namespace Gui.Misc
@@ -8,7 +9,7 @@ namespace Gui.Misc
     {
         public delegate void BeatmapsEventArgs(object sender, Beatmaps args);
         public delegate void CollectionBeatmapsEventArgs(object sender, Beatmaps args, string collectionName);
-        public delegate void CollectionReorderEventArgs(object sender, Collections collections, Collection targetCollection, bool placeBefore, string sortColumn, int sortOrder);
+        public delegate void CollectionReorderEventArgs(object sender, Collections collections, Collection targetCollection, bool placeBefore, string sortColumn, SortOrder sortOrder);
         public delegate void BeatmapListingActionArgs(object sender, BeatmapListingAction args);
         public delegate void SidePanelActionsHandlerArgs(object sender, MainSidePanelActions args, object data = null);
         public delegate void LoadFileArgs(object sender, string[] filePaths);

--- a/GuiComponents/Controls/BeatmapListingView.cs
+++ b/GuiComponents/Controls/BeatmapListingView.cs
@@ -118,7 +118,7 @@ namespace GuiComponents.Controls
             //listview
             ListViewBeatmaps.FullRowSelect = true;
             ListViewBeatmaps.AllowColumnReorder = true;
-            ListViewBeatmaps.Sorting = SortOrder.Descending;
+            ListViewBeatmaps.Sorting = System.Windows.Forms.SortOrder.Descending;
             ListViewBeatmaps.UseHotItem = true;
             ListViewBeatmaps.UseTranslucentHotItem = true;
             ListViewBeatmaps.UseFiltering = true;

--- a/GuiComponents/Controls/CollectionListingView.cs
+++ b/GuiComponents/Controls/CollectionListingView.cs
@@ -203,14 +203,16 @@ namespace GuiComponents.Controls
             var targetCollection = (Collection)e.TargetModel;
             if (e.SourceModels[0] is Collection)
             {
-                if (ListViewCollections.LastSortColumn != NameColumn || ListViewCollections.LastSortOrder != SortOrder.Ascending)
-                    ListViewCollections.Sort(ListViewCollections.AllColumns[0], SortOrder.Ascending);
 
                 var collections = new Collections();
                 foreach (var collection in e.SourceModels)
                     collections.Add((Collection)collection);
 
-                OnCollectionReorder?.Invoke(this, collections, targetCollection, e.DropTargetLocation == DropTargetLocation.AboveItem);
+                OnCollectionReorder?.Invoke(this, collections, targetCollection, e.DropTargetLocation == DropTargetLocation.AboveItem, ListViewCollections.LastSortColumn.Text, (int)ListViewCollections.LastSortOrder);
+
+                if (ListViewCollections.LastSortColumn != NameColumn || ListViewCollections.LastSortOrder != SortOrder.Ascending)
+                    ListViewCollections.Sort(ListViewCollections.AllColumns[0], SortOrder.Ascending);
+
                 return;
             }
 

--- a/GuiComponents/Controls/CollectionListingView.cs
+++ b/GuiComponents/Controls/CollectionListingView.cs
@@ -211,7 +211,7 @@ namespace GuiComponents.Controls
                 var sortOrder = ListViewCollections.LastSortOrder == SortOrder.Ascending 
                     ? CollectionManager.Enums.SortOrder.Ascending 
                     : CollectionManager.Enums.SortOrder.Descending;
-                OnCollectionReorder?.Invoke(this, collections, targetCollection, e.DropTargetLocation == DropTargetLocation.AboveItem, ListViewCollections.LastSortColumn.Text, sortOrder);
+                OnCollectionReorder?.Invoke(this, collections, targetCollection, e.DropTargetLocation == DropTargetLocation.AboveItem, ListViewCollections.LastSortColumn.AspectName, sortOrder);
 
                 if (ListViewCollections.LastSortColumn != NameColumn || ListViewCollections.LastSortOrder != SortOrder.Ascending)
                     ListViewCollections.Sort(ListViewCollections.AllColumns[0], SortOrder.Ascending);

--- a/GuiComponents/Controls/CollectionListingView.cs
+++ b/GuiComponents/Controls/CollectionListingView.cs
@@ -208,7 +208,10 @@ namespace GuiComponents.Controls
                 foreach (var collection in e.SourceModels)
                     collections.Add((Collection)collection);
 
-                OnCollectionReorder?.Invoke(this, collections, targetCollection, e.DropTargetLocation == DropTargetLocation.AboveItem, ListViewCollections.LastSortColumn.Text, (int)ListViewCollections.LastSortOrder);
+                var sortOrder = ListViewCollections.LastSortOrder == SortOrder.Ascending 
+                    ? CollectionManager.Enums.SortOrder.Ascending 
+                    : CollectionManager.Enums.SortOrder.Descending;
+                OnCollectionReorder?.Invoke(this, collections, targetCollection, e.DropTargetLocation == DropTargetLocation.AboveItem, ListViewCollections.LastSortColumn.Text, sortOrder);
 
                 if (ListViewCollections.LastSortColumn != NameColumn || ListViewCollections.LastSortOrder != SortOrder.Ascending)
                     ListViewCollections.Sort(ListViewCollections.AllColumns[0], SortOrder.Ascending);


### PR DESCRIPTION
This makes it possible to sort collections by Count, Missing, and Id and have them stay in that order when reordering them using name.
One small thing with this is that it wont always reorder same numbers in the same order as they are viewed for Count and Missing. For example, if there are many collections that each have 1 map those maps with matching numbers may end up in a different order than is displayed. The filters seem to have this issue as well though, with count and missing flipping through three different outcomes for some reason.