### PR TITLE
Fix: Update UserAgent

### DIFF
--- a/CollectionManagerExtensionsDll/Modules/DownloadManager/API/CookieAwareWebClient.cs
+++ b/CollectionManagerExtensionsDll/Modules/DownloadManager/API/CookieAwareWebClient.cs
@@ -8,7 +8,7 @@ namespace System.Net
     public class CookieAwareWebClient : WebClient
     {
         public int ClientId = -1;
-        public string UserAgent { get; set; } = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Safari/537.36";
+        public string UserAgent { get; set; } = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36";
         public int RequestTimeout { get; set; } = 5000;
         public void SetCookies(string cookies, string[] cookiesToIgnore, string cookieDomain)
         {


### PR DESCRIPTION
This PR updates the user agent to stop some mirrors from blocking API requests due to an old Chrome version.