### PR TITLE
Fix: Lazer realm load times

### DIFF
--- a/CollectionManagerDll/DataTypes/LazerBeatmap.cs
+++ b/CollectionManagerDll/DataTypes/LazerBeatmap.cs
@@ -1,9 +1,14 @@
-﻿namespace CollectionManager.DataTypes;
+﻿using CollectionManager.Extensions;
+using System.Linq;
+
+namespace CollectionManager.DataTypes;
 
 public class LazerBeatmap
     : BeatmapExtension
 {
-    public string AudioRelativeFilePath { get; set; }
-    public string BackgroundRelativeFilePath { get; set; }
+    public string BackgroundFileName { get; set; }
+    public string AudioRelativeFilePath => SetFiles.FirstOrDefault(f => f.FileName == Mp3Name)?.RelativeRealmFilePath;
+    public string BackgroundRelativeFilePath => SetFiles.FirstOrDefault(f => f.FileName == BackgroundFileName)?.RelativeRealmFilePath;
     public string MapHash { get; set; }
+    public LazerFile[] SetFiles { get; set; }
 }

--- a/CollectionManagerDll/DataTypes/LazerFile.cs
+++ b/CollectionManagerDll/DataTypes/LazerFile.cs
@@ -1,0 +1,11 @@
+﻿using System.IO;
+
+namespace CollectionManager.DataTypes;
+
+public class LazerFile(string Hash, string FileName)
+{
+    public string Hash { get; } = Hash;
+    public string FileName { get; } = FileName;
+
+    public string RelativeRealmFilePath => Path.Combine(Hash.Remove(1), Hash.Remove(2), Hash);
+}

--- a/CollectionManagerDll/Extensions/BeatmapSetInfoExtensions.cs
+++ b/CollectionManagerDll/Extensions/BeatmapSetInfoExtensions.cs
@@ -1,0 +1,16 @@
+﻿using CollectionManager.DataTypes;
+using CollectionManager.Interfaces;
+using CollectionManager.Modules.FileIO.OsuLazerDb.RealmModels;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace CollectionManager.Extensions;
+internal static class BeatmapSetInfoExtensions
+{
+    public static IEnumerable<LazerBeatmap> ToLazerBeatmaps(this BeatmapSetInfo beatmapSetInfo, IScoreDataManager scoreDataManager)
+    {
+        LazerFile[] setFiles = beatmapSetInfo.Files.Select(namedFile => namedFile.ToLazerFile()).ToArray();
+
+        return beatmapSetInfo.Beatmaps.Select(beatmap => beatmap.ToLazerBeatmap(scoreDataManager, setFiles));
+    }
+}

--- a/CollectionManagerDll/Extensions/RealmNamedFileUsageExtensions.cs
+++ b/CollectionManagerDll/Extensions/RealmNamedFileUsageExtensions.cs
@@ -1,0 +1,9 @@
+﻿using CollectionManager.DataTypes;
+using CollectionManager.Modules.FileIO.OsuLazerDb.RealmModels;
+
+namespace CollectionManager.Extensions;
+internal static class RealmNamedFileUsageExtensions
+{
+    public static LazerFile ToLazerFile(this RealmNamedFileUsage realmNamedFile)
+        => new(realmNamedFile.File.Hash, realmNamedFile.Filename);
+}


### PR DESCRIPTION
#92

In local testing with ~92k beatmaps (~22k sets), this brings load times down to ~13 seconds from over an minute previously.