### PR TITLE
Misc: Bump realm version

### DIFF
--- a/CollectionManager.Core/Modules/FileIO/OsuRealmReader.cs
+++ b/CollectionManager.Core/Modules/FileIO/OsuRealmReader.cs
@@ -5,7 +5,7 @@ using System.Text.RegularExpressions;
 
 public partial class OsuRealmReader
 {
-    private const ulong _lastValidatedRealmSchemaVersion = 48;
+    private const ulong _lastValidatedRealmSchemaVersion = 49;
     [GeneratedRegex("(\\d+)(?!.*\\d)")]
     private static partial Regex LastNumberRegex();
 


### PR DESCRIPTION
osu!(lazer) tachyon expects 49 instead of 48!
the number has to be swapped to 49 to work!