### PR TITLE
Fix: Handle NullReferenceException in PullWholeMapsets

### DIFF
--- a/App/BeatmapListingActionsHandler.cs
+++ b/App/BeatmapListingActionsHandler.cs
@@ -52,7 +52,7 @@ public class BeatmapListingActionsHandler
     private void PullWholeMapsets(object sender)
     {
         IBeatmapListingModel model = (IBeatmapListingModel)sender;
-        if (model.SelectedBeatmaps?.Count > 0)
+        if (Initalizer.CollectionEditor != null && model.SelectedBeatmaps?.Count > 0 && model.CurrentCollection != null)
         {
             Beatmaps setBeatmaps = [];
 


### PR DESCRIPTION
Added null checks for Initalizer.CollectionEditor and model.CurrentCollection to prevent a NullReferenceException when pulling whole mapsets.